### PR TITLE
Imperfect split translate input/circuit, save 1 minute in translate input

### DIFF
--- a/libsnark/jsnark_interface/CircuitReader.cpp
+++ b/libsnark/jsnark_interface/CircuitReader.cpp
@@ -13,6 +13,7 @@ CircuitReader::CircuitReader(char* arithFilepath, char* inputsFilepath,
 	numWires = 0;
 	numInputs = numNizkInputs = numOutputs = 0;
 
+    // Timing below is measured on i7-10875H, 64G RAM laptop, tlsNotary circuit (4M constraint version)
 	parseAndEval(arithFilepath, inputsFilepath); // 14s
 	constructCircuit(arithFilepath); // 33s
 	mapValuesToProtoboard(); // 14s

--- a/libsnark/jsnark_interface/CircuitReader.cpp
+++ b/libsnark/jsnark_interface/CircuitReader.cpp
@@ -13,9 +13,9 @@ CircuitReader::CircuitReader(char* arithFilepath, char* inputsFilepath,
 	numWires = 0;
 	numInputs = numNizkInputs = numOutputs = 0;
 
-	parseAndEval(arithFilepath, inputsFilepath);
-	constructCircuit(arithFilepath);
-	mapValuesToProtoboard();
+	parseAndEval(arithFilepath, inputsFilepath); // 14s
+	constructCircuit(arithFilepath); // 33s
+	mapValuesToProtoboard(); // 14s
 
 	wireLinearCombinations.clear();
 	wireValues.clear();

--- a/libsnark/jsnark_interface/run_ppzksnark.cpp
+++ b/libsnark/jsnark_interface/run_ppzksnark.cpp
@@ -109,12 +109,38 @@ int main(int argc, char **argv) {
 	}
 	case TranslateInput:
 	{
-		// assert(argc == 5);
-		// char *in_filename = argv[2];
-		// char *primary_input_filename = argv[3];
-		// char *auxiliary_input_filename = argv[4];
-		// cout << "Translate Input" << endl;
-		// break;
+        assert(argc == 7);
+        char *arith_filename = argv[2];
+        char *in_filename = argv[3];
+        char *circuit_filename = argv[4];
+        char *output_primary_input_filename = argv[5];
+        char *output_auxiliary_input_filename = argv[6];
+        cout << "Translate Circuit and Input" << endl;
+        CircuitReader reader(arith_filename, in_filename, pb);
+
+        r1cs_constraint_system<FieldT> cs;
+        std::ifstream ci(circuit_filename, ios::binary | ios::in);
+        ci >> cs;
+        ci.close();
+
+        const r1cs_variable_assignment<FieldT> full_assignment = get_variable_assignment_from_gadgetlib2(*pb);
+        cs.primary_input_size = reader.getNumInputs() + reader.getNumOutputs();
+        cs.auxiliary_input_size = full_assignment.size() - cs.num_inputs();
+        std::cout << cs.primary_input_size << std::endl;
+        const r1cs_primary_input<FieldT> primary_input(full_assignment.begin(),
+                                                       full_assignment.begin() + cs.num_inputs());
+        const r1cs_auxiliary_input<FieldT> auxiliary_input(
+                full_assignment.begin() + cs.num_inputs(), full_assignment.end());
+
+        std::ofstream opi(output_primary_input_filename, ios::binary | ios::out);
+        std::cout << "=======================" << std::endl;
+        opi << primary_input;
+        opi.close();
+        std::cout << "-----------------------" << std::endl;
+        std::ofstream oai(output_auxiliary_input_filename, ios::binary | ios::out);
+        oai << auxiliary_input;
+        oai.close();
+        break;
 	}
 	case Generate:
 	{

--- a/libsnark/jsnark_interface/run_ppzksnark.cpp
+++ b/libsnark/jsnark_interface/run_ppzksnark.cpp
@@ -78,10 +78,9 @@ int main(int argc, char **argv) {
 		oc << cs;
 		oc.close();
 		std::ofstream opi(output_primary_input_filename, ios::binary | ios::out);
-        std::cout << "=======================" << std::endl;
 		opi << primary_input;
 		opi.close();
-        std::cout << "-----------------------" << std::endl;
+
         std::ofstream oai(output_auxiliary_input_filename, ios::binary | ios::out);
 		oai << auxiliary_input;
 		oai.close();
@@ -95,7 +94,7 @@ int main(int argc, char **argv) {
         char *circuit_filename = argv[4];
         char *output_primary_input_filename = argv[5];
         char *output_auxiliary_input_filename = argv[6];
-        cout << "Translate Circuit and Input" << endl;
+        cout << "Translate Input" << endl;
         CircuitReader reader(arith_filename, in_filename, pb);
         std::ifstream ci(circuit_filename, ios::binary | ios::in);
         size_t primary_input_size;
@@ -108,10 +107,9 @@ int main(int argc, char **argv) {
                 full_assignment.begin() + primary_input_size, full_assignment.end());
 
         std::ofstream opi(output_primary_input_filename, ios::binary | ios::out);
-        std::cout << "=======================" << std::endl;
         opi << primary_input;
         opi.close();
-        std::cout << "-----------------------" << std::endl;
+
         std::ofstream oai(output_auxiliary_input_filename, ios::binary | ios::out);
         oai << auxiliary_input;
         oai.close();

--- a/libsnark/jsnark_interface/run_ppzksnark.cpp
+++ b/libsnark/jsnark_interface/run_ppzksnark.cpp
@@ -16,7 +16,6 @@
 #include <fstream>
 
 enum Command {
-	TranslateCircuit,
 	TranslateInput,
 	Translate,
 	Generate,
@@ -35,9 +34,7 @@ int main(int argc, char **argv) {
 
 	int inputStartIndex = 0;
 	assert(argc > 2);
-	if (strcmp(argv[1], "translate_circuit") == 0) {
-		cmd = TranslateCircuit;
-	} else if (strcmp(argv[1], "translate_input") == 0) {
+    if (strcmp(argv[1], "translate_input") == 0) {
 		cmd = TranslateInput;
 	} else if (strcmp(argv[1], "translate") == 0) {
 		cmd = Translate;
@@ -56,24 +53,6 @@ int main(int argc, char **argv) {
 
 	cout << "Using ppzsknark in the generic group model [Groth16]." << endl;
 	switch (cmd) {
-	case TranslateCircuit:
-	{		
-		assert(argc == 5);
-		char *arith_filename = argv[2];
-		char *output_circuit_filename = argv[3];
-		char *output_metadata_filename = argv[4];
-		cout << "Translate Circuit" << endl;
-		CircuitReader reader(arith_filename, pb);
-		r1cs_constraint_system<FieldT> cs = get_constraint_system_from_gadgetlib2(*pb);
-		std::ofstream cs_out(output_circuit_filename, ios::binary | ios::out);
-		cs_out << cs;
-		cs_out.close();
-		std::ofstream m_out(output_metadata_filename, ios::out);
-		m_out << cs.primary_input_size + cs.auxiliary_input_size << endl;
-		// TODO: more metadata
-		m_out.close();
-		break;
-	}
 	case Translate:
 	{
 		// Translate Input seems challenging to write, as first step, use this translate circuit + translate input combination

--- a/libsnark/jsnark_interface/run_ppzksnark.cpp
+++ b/libsnark/jsnark_interface/run_ppzksnark.cpp
@@ -65,6 +65,7 @@ int main(int argc, char **argv) {
 		cout << "Translate Circuit and Input" << endl;
 		CircuitReader reader(arith_filename, in_filename, pb);
 		r1cs_constraint_system<FieldT> cs = get_constraint_system_from_gadgetlib2(*pb);
+        // 10688740
 		const r1cs_variable_assignment<FieldT> full_assignment = get_variable_assignment_from_gadgetlib2(*pb);
 		cs.primary_input_size = reader.getNumInputs() + reader.getNumOutputs();
 		cs.auxiliary_input_size = full_assignment.size() - cs.num_inputs();
@@ -96,20 +97,15 @@ int main(int argc, char **argv) {
         char *output_auxiliary_input_filename = argv[6];
         cout << "Translate Circuit and Input" << endl;
         CircuitReader reader(arith_filename, in_filename, pb);
-
-        r1cs_constraint_system<FieldT> cs;
         std::ifstream ci(circuit_filename, ios::binary | ios::in);
-        ci >> cs;
+        size_t primary_input_size;
+        ci >> primary_input_size;
         ci.close();
-
         const r1cs_variable_assignment<FieldT> full_assignment = get_variable_assignment_from_gadgetlib2(*pb);
-        cs.primary_input_size = reader.getNumInputs() + reader.getNumOutputs();
-        cs.auxiliary_input_size = full_assignment.size() - cs.num_inputs();
-        std::cout << cs.primary_input_size << std::endl;
         const r1cs_primary_input<FieldT> primary_input(full_assignment.begin(),
-                                                       full_assignment.begin() + cs.num_inputs());
+                                                       full_assignment.begin() + primary_input_size);
         const r1cs_auxiliary_input<FieldT> auxiliary_input(
-                full_assignment.begin() + cs.num_inputs(), full_assignment.end());
+                full_assignment.begin() + primary_input_size, full_assignment.end());
 
         std::ofstream opi(output_primary_input_filename, ios::binary | ios::out);
         std::cout << "=======================" << std::endl;


### PR DESCRIPTION
Before:
```
jsnark_interface (modular) time ./run_ppzksnark translate TLSNotaryCheck.arith TLSNotaryCheck_Sample_Run1.in tls_circuit_new tls_primary_in_new tls_aux_in_new | tee log
Reset time counters for profiling
Using ppzsknark in the generic group model [Groth16].
Translate Circuit and Input
(enter) Parsing and Evaluating the circuit      [             ] (0.0009s x1.00 from start)
(leave) Parsing and Evaluating the circuit      [14.1780s x1.00]        (14.1789s x1.00 from start)
(enter) Call to constructCircuit                [             ] (14.1789s x1.00 from start)
        Constraint translation done
        Memory usage for constraint translation: 5399 MB
(leave) Call to constructCircuit                [34.1612s x1.00]        (48.3401s x1.00 from start)
Assignment of values done .. 
(enter) Call to get_constraint_system_from_gadgetlib2   [             ] (63.9010s x1.00 from start)
=================
0 4383349
(leave) Call to get_constraint_system_from_gadgetlib2   [53.6181s x1.00]        (117.5191s x1.00 from start)
(enter) Call to get_variable_assignment_from_gadgetlib2 [             ] (118.3902s x1.00 from start)
(leave) Call to get_variable_assignment_from_gadgetlib2 [1.3483s x1.00] (119.7385s x1.00 from start)
9
=======================
-----------------------

real    2m10.118s
user    2m5.473s
sys     0m4.368s
```

After:
```
time ./run_ppzksnark translate_input TLSNotaryCheck.arith TLSNotaryCheck_Sample_Run1.in tls_circuit_new tls_primary_in_new tls_aux_in_new | tee log
Reset time counters for profiling
Using ppzsknark in the generic group model [Groth16].
Translate Circuit and Input
(enter) Parsing and Evaluating the circuit      [             ] (0.0008s x1.00 from start)
(leave) Parsing and Evaluating the circuit      [13.9451s x1.00]        (13.9459s x1.00 from start)
(enter) Call to constructCircuit                [             ] (13.9459s x1.00 from start)
        Constraint translation done
        Memory usage for constraint translation: 5399 MB
(leave) Call to constructCircuit                [32.6854s x1.00]        (46.6313s x1.00 from start)
Assignment of values done .. 
(enter) Call to get_variable_assignment_from_gadgetlib2 [             ] (67.4447s x1.00 from start)
(leave) Call to get_variable_assignment_from_gadgetlib2 [0.7522s x1.00] (68.1969s x1.00 from start)
9
=======================
-----------------------

real    1m13.179s
user    1m10.263s
sys     0m2.884s
```

The new workflow is, on first run, user call `translate`. On second and following runs, user call `./run_ppzksnark translate_input ...`, which takes both the `.arith` and circuit file (constraint systems). It avoids a conversion from `.arith` to constraint system which saves about 1 minute.
